### PR TITLE
fix: add missing dependabot configuration for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2025 Chen Linxuan <me@black-desk.cn>
+#
+# SPDX-License-Identifier: MIT
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
- Add .github/dependabot.yml to configure automatic updates for GitHub Actions
- Set weekly update schedule with up to 10 open pull requests
- Resolves CI failure due to missing dependabot coverage for github-actions ecosystem

This addresses the dependabot coverage report failure in CI workflows.

Note: Changes and commit message generated by GitHub Copilot
